### PR TITLE
Switch to babel-loader for TypeScript

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,5 @@
 import { configure } from "@storybook/react";
-const req = require.context("../src", true, /.stories.tsx$/);
+const req = require.context("../src/stories", true, /\.stories\.tsx?$/);
 function loadStories() {
   req.keys().forEach(req);
 }

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,21 +1,20 @@
-const path = require("path");
-const SRC_PATH = path.join(__dirname, "../src");
-const STORIES_PATH = path.join(__dirname, "../stories");
+// const path = require("path");
+// const SRC_PATH = path.join(__dirname, "../src");
+// const STORIES_PATH = path.join(__dirname, "../stories");
 //dont need stories path if you have your stories inside your //components folder
 module.exports = ({ config }) => {
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
-    include: [SRC_PATH, STORIES_PATH],
     use: [
-      {
-        loader: require.resolve("awesome-typescript-loader"),
+      { loader: require.resolve("babel-loader"),
         options: {
-          configFileName: "./.storybook/tsconfig.json"
-        }
+          presets: [["react-app", { flow: false, typescript: true }]],
+        },
       },
-      { loader: require.resolve("react-docgen-typescript-loader") }
-    ]
+      { loader: require.resolve("react-docgen-typescript-loader") },
+    ],
   });
   config.resolve.extensions.push(".ts", ".tsx");
+
   return config;
 };

--- a/package.json
+++ b/package.json
@@ -3,21 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/jest": "^24.0.23",
-    "@types/node": "^12.12.14",
-    "@types/react": "^16.9.15",
-    "@types/react-dom": "^16.9.4",
     "grommet": "^2.8.1",
     "grommet-icons": "^4.4.0",
     "grommet-theme-hpe": "^0.4.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-scripts": "3.3.0",
-    "styled-components": "^4.4.1",
-    "typescript": "^3.7.3"
+    "styled-components": "^4.4.1"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -43,8 +34,17 @@
   },
   "devDependencies": {
     "@storybook/react": "^5.2.8",
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/user-event": "^7.1.2",
+    "@types/jest": "^24.0.23",
+    "@types/node": "^12.12.14",
+    "@types/react": "^16.9.15",
+    "@types/react-dom": "^16.9.4",
     "awesome-typescript-loader": "^5.2.1",
     "react-docgen-typescript-loader": "^3.6.0",
-    "react-docgen-typescript-webpack-plugin": "^1.1.0"
+    "react-docgen-typescript-webpack-plugin": "^1.1.0",
+    "react-scripts": "3.3.0",
+    "typescript": "^3.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/core": "^7.7.5",
     "@storybook/react": "^5.2.8",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
@@ -41,7 +42,7 @@
     "@types/node": "^12.12.14",
     "@types/react": "^16.9.15",
     "@types/react-dom": "^16.9.4",
-    "awesome-typescript-loader": "^5.2.1",
+    "babel-loader": "^8.0.6",
     "react-docgen-typescript-loader": "^3.6.0",
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
     "react-scripts": "3.3.0",


### PR DESCRIPTION
Using babel-loader to load typescript in Storybook works while using awesome-typescript-loader does not.